### PR TITLE
better queue control, reduced process creation overhead

### DIFF
--- a/object_oriented/pipelines.py
+++ b/object_oriented/pipelines.py
@@ -1,13 +1,34 @@
 '''
 classes that can be used as the base of ETL pipelines. Pipeline characteristics:
-    - work and management functions for a bounded (in memory and cpu usage), logged, 
+    - work and management functions for a memory bounded, logged, 
         and fully asynchronous multiprocess ETL application
     - design prevents unbounded memory/process number growth that can occur in 
         multiprocess ETL python applications
     - process management will dominate usage if work elements are small
-    - attempts to implement multiprocess logging (works in my tests, see run_pipe.py)
+    - attempts to implement multiprocess logging
 
 Author: Raymond Gasper
+
+Usage Notes:
+- Getting data out of the pipeline-
+you have two options:
+    - *concurrently* consume from an output queue in another thread/process. 
+        WARNING! if you just accumulate into the queue and dont collect concurrently, 
+            the pipeline will never finish (it will block on consumer.join())
+        WARNING! if you do not use queue.task_done() the pipeline will never finish
+    - write to an external data store (csv, database)
+
+- Logging -
+easiest and only currently verified way:
+    - from logging import debug, info, warn, error, critical
+    - put loglevel() calls in your work functions
+    - use a dictConfig() at the very top of main .py
+
+Memory stability testing:
+I've tested upto 10K elements of 1000 integer long lists with 4 serial pools of 
+25 concurrent workers, and have seen no evidence of memory load increasing during 
+runtime. The main thread allocated a somewhat frightening 260 MB of memory (no work 
+data, just child process info) but it stayed constant during runtime!
 '''
 
 from logging import debug, info, exception
@@ -21,7 +42,8 @@ from inspect import isgeneratorfunction
 # from random import randint # used to simulate data loss
 
 def _producer(out_queue, total, producer_func, producer_config_args):
-    ''' pushes stuff into the pipeline, dies when there is no more work 
+    ''' A generator that pushes stuff into the pipeline, 
+    dies when there is no more work 
     :params:
         out_queue - multiprocessing.Queue: where to put outgoing data
         total - multiprocessing.Value: track how many elements were generated
@@ -39,7 +61,7 @@ def _worker(in_queue, out_queue, worker_func, worker_config_args, worker_get_lim
     out_queue - multiprocessing.Queue: where to put outgoing data
     worker_func - callable: does something to the data
     worker_config_args - tuple: all arguments except first (input data) for worker
-    worker_get_limit: int- number of times workers get and process data before dying
+    worker_get_limit: int- number of times worker gets and processes data before dying
     '''
     for _ in range(worker_get_limit):
         i = in_queue.get()
@@ -50,7 +72,7 @@ def _worker(in_queue, out_queue, worker_func, worker_config_args, worker_get_lim
 
 
 def _consumer(in_queue, total, consumer_func, consumer_config_args, flag):
-    ''' does something with the pipeline results, like writing to storage     
+    ''' does something with the pipeline results, like writing to storage    
     :params:
         in_queue - multiprocessing.Queue: where to get incoming data
         total - multiprocessing.Value: track how many elements were generated
@@ -79,9 +101,8 @@ def _consumer(in_queue, total, consumer_func, consumer_config_args, flag):
     info('completed')
 
 
-def manager(tag, in_queue, worker_func, worker_config_args, n_processes, flag, worker_get_limit):
-    ''' manages a set of concurrent processes defined by worker_func and worker_config_args 
-    does not deliver or return any data 
+def _manager(tag, in_queue, worker_func, worker_config_args, n_processes, flag, worker_get_limit):
+    ''' manages a set of concurrent daemon child processes until the data is gone, then dies
     :params:
         tag: printable - an identifier for this manager
         in_queue: multiprocessing.Queue- input data for workers. manager observes queue 
@@ -135,16 +156,13 @@ def manager(tag, in_queue, worker_func, worker_config_args, n_processes, flag, w
 class ConcurrentSingleElementPipeline:
     ''' Runs a concurrent asynchronous ETL pipeline with the provided functions.
     Currently only allows single producer, single consumer, but multiple serial pipe 
-    functions. Worker Processes restricted to handling one input element at a time.
+    worker functions (in concurrent pools!). Workers restricted to handling one input 
+    element at a time. Will automatically check for lost data at end of execution.
 
-    see run_pipe.py for simple example usage
-
-    The funcs and matching args must be defined carefully!
+    !NOTE! The functions and matching args must be defined carefully!
     - producer function must be a generator function
     - pipe functions must take an input data object as their _first_ argument
     - consumer function must take an input data as its _first_ argument
-    - In case of flawed data, pass nothing. class will check to see if number of produced
-        elements at the start matches the number of consumed elements at the end
 
     When defining pipe_funcs, order matters!
     - first pipe_func receives input from producer
@@ -153,14 +171,8 @@ class ConcurrentSingleElementPipeline:
     
     all functions (producer, pipe_funcs, and consumer) are responsible for their own input
     sanitation and error handling. All this does is manage process pools and data queues. 
-    Pipe_funcs are daemonized and so cannot have their own child processes.
-
-    If you want to use poisonPills to control consumer or worker behavior, just yield at the end of 
-    the producer function.
-
-    If you want data from the pipeline to pass into the main thread, DO NOT accumulate into a queue
-    that does not have a main process thread async collecting. It will cause weird errors. See run_pipe.py
-    for a more detailed description.
+    Pipe_funcs are daemonized and so cannot have their own child processes. Do your best to
+    not use poisonPills, it will be very hard to ensure data queue behavior that makes sense.
     '''
     # TODO: allow producer_func to also be a producer_object (GeneratorType)
     #       complications:
@@ -283,7 +295,7 @@ class ConcurrentSingleElementPipeline:
         )
         for i in range(self.N):
             self._managers[i] = Process(
-                target = manager,
+                target = _manager,
                 args = (
                     i,
                     self._queues[i],

--- a/object_oriented/run_pipe.py
+++ b/object_oriented/run_pipe.py
@@ -4,29 +4,8 @@ running validation of result accuracy
 pipeline validates no data loss
 
 logging works, memory is stable, CTRL-c works as fast as the workers can get to it,
-and exit is clean - no child process left behind.
+and exit is always clean - no child process left behind.
 -nice-
-
-Notes:
-SO i've done some experimenting and if you want to get data out of the pipeline,
-you have two options:
-    - _constantly_ consume from an output queue in another thread/process. 
-        If you let it accumulate, it will eventually block forever with no error
-        even if you use put_nowait() or put(block=False) in the consumer. see WEIRD QUEUE ERROR
-        (using Python 2.7 and Mac OS X)
-    - write to an external data store (csv, database)
-
-WEIRD QUEUE ERROR:
-If you accumulate data into a Queue for collection into Main Thread, a weird error can occur!
-The ConcurrentSingleElementPipeline._consumer will never successfully join. It gets to it's return
-statement, will execute code after the last queue.put().
-I'm 95% sure this is what is happening, and have tested thoroughly. 
-It makes _absolutely_ no sense to me. Maybe need to use managers instead of multiprocessing.Queue
-
-Memory usage:
-I've tested upto 10K elements of 1000 integer long lists with 4 serial pools of 25 concurrent workers,
-and have seen no evidence of memory load increasing during runtime. The main thread consumed a frightening
-260 MB of memory but it stayed constant during runtime.
 '''
 from pipelines import ConcurrentSingleElementPipeline
 

--- a/object_oriented/run_pipe.py
+++ b/object_oriented/run_pipe.py
@@ -59,10 +59,11 @@ log_config = {
 }
 dictConfig(log_config)
 
-num_elements = 100
+num_elements = 55
 element_size = 10
-num_serial_workers = 5
-num_parallel_workers = 5
+num_serial_workers = 3
+num_parallel_workers = 3
+worker_get_limit = 10
 
 def my_producer(num_elements, element_size):
     for _ in range(num_elements):
@@ -98,6 +99,7 @@ etl = ConcurrentSingleElementPipeline(
     pipe_funcs              = tuple([my_worker]*num_serial_workers),
     pipe_funcs_config_args  = tuple([()]*num_serial_workers),
     pipe_n_procs            = tuple([num_parallel_workers]*num_serial_workers),
+    worker_get_limit        = worker_get_limit
 )
 etl.run()
-info('if my_consumer didnt throw an assertion error, it worked!')
+info('no major errors in main process, check logs to see if there was data loss or issues in child processes')

--- a/object_oriented/run_pipe.py
+++ b/object_oriented/run_pipe.py
@@ -32,6 +32,8 @@ from pipelines import ConcurrentSingleElementPipeline
 
 from logging.config import dictConfig
 from logging import debug, info, error
+from random import randint
+from time import sleep
 
 log_config = {
     "version": 1,
@@ -59,8 +61,8 @@ dictConfig(log_config)
 
 num_elements = 100
 element_size = 10
-num_serial_workers = 2
-num_parallel_workers = 2
+num_serial_workers = 5
+num_parallel_workers = 5
 
 def my_producer(num_elements, element_size):
     for _ in range(num_elements):
@@ -68,6 +70,7 @@ def my_producer(num_elements, element_size):
 
 # first (and in this case only) argument is input data
 def my_worker(inp):
+    sleep(randint(0,250)/100)
     return [i**2 for i in inp]
 
 # first (and only) argument is input data


### PR DESCRIPTION
used .task_done() after .get() like I should've
- Simplifies process pool completion signals
- seems faster
- just about better in every way

also, workers can operate on more than one chunk of data before quitting
- reduces process creation and cleanup overhead

A lot of documentation tweaks/improvements